### PR TITLE
feat: ignore front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Here's the breakdown of the available options:
 | `-H, --heading TEXT`        | Text to show as the list heading. Default is "". Example: `findlike reference_file.txt -H "## Similar files"`                                                                                                                                                                                                                         |
 | `-F, --format [plain, json]` | This option sets the output format. Default is "plain". Example: `findlike reference_file.txt -F json`                                                       |
 | `-t, --threshold FLOAT`     | Similarity score threshold. All results whose score are below the determined threshold will be omitted. Default is 0.05. Example: `findlike reference_file.txt -t 0`                                                                                                                                                                  |
+| `-i, --ignore-front-matter` | Tries to strip the front-matter from markup files like Markdown and Org-mode. |
 
 ## Examples
 

--- a/findlike/cli.py
+++ b/findlike/cli.py
@@ -116,6 +116,13 @@ from .constants import FORMATTER_CLASSES, ALGORITHM_CLASSES, TEXT_FILE_EXT
     required=False,
 )
 @click.option(
+    "--ignore-front-matter",
+    "-i",
+    is_flag=True,
+    help="ignore front-matter from supported markup languages",
+    required=False,
+)
+@click.option(
     "--heading",
     "-H",
     type=str,
@@ -159,6 +166,7 @@ def cli(
     format,
     threshold,
     absolute_paths,
+    ignore_front_matter,
 ):
     """'findlike' is a program that scans a given directory and returns the most
     similar documents in relation to REFERENCE_FILE or --query QUERY.
@@ -175,8 +183,10 @@ def cli(
     # Set up the reference text.
     if reference_file:
         reference_content = try_read_file(Path(reference_file))
+        reference_extension = Path(reference_file).suffix
     elif query:
         reference_content = query
+        reference_extension = None
     else:
         raise click.UsageError(
             "Neither REFERENCE_FILE nor --query QUERY was provided."
@@ -184,14 +194,21 @@ def cli(
 
     # Put together the list of documents to be analyzed.
     directory_path = Path(directory)
-    extensions: list[str] = [filename_pattern] if filename_pattern else TEXT_FILE_EXT
+    extensions: list[str] = (
+        [filename_pattern] if filename_pattern else TEXT_FILE_EXT
+    )
     document_paths = collect_paths(
         directory=directory_path, extensions=extensions, recursive=recursive
     )
 
     # Create a corpus with the collected documents.
-    corpus = Corpus(paths=document_paths, min_chars=min_chars)
-    corpus.add_document(document=reference_content)
+    corpus = Corpus(
+        paths=document_paths,
+        min_chars=min_chars,
+        ignore_front_matter=ignore_front_matter,
+    )
+    if reference_content:
+        corpus.add_document(document=reference_content, extension=reference_extension)
 
     # Set up the documents pre-processor.
     stemmer = SnowballStemmer(language).stem
@@ -199,7 +216,7 @@ def cli(
         stopwords=get_stop_words(language=language),
         stemmer=stemmer,
     )
-    
+
     # Set up the similarity model.
     model = ALGORITHM_CLASSES[algorithm](processor=processor)
     model.fit(corpus.documents_)  # Add reference to avoid zero division

--- a/findlike/constants.py
+++ b/findlike/constants.py
@@ -198,7 +198,7 @@ TEXT_FILE_EXT = [
 	"*.nuspec",
 	"*.nvmrc",
 	"*.ops",
-    "org",
+    "*.org",
 	"*.pas",
 	"*.pasm",
 	"*.patch",

--- a/findlike/markup.py
+++ b/findlike/markup.py
@@ -8,7 +8,10 @@ class Markup:
         }
 
     def strip_frontmatter(self, text: str) -> str:
-            return self._MARKUP_EXTENSIONS[self.extension](text)
+            if self.extension in self._MARKUP_EXTENSIONS.keys():
+                return self._MARKUP_EXTENSIONS[self.extension](text)
+            else:
+                return text
 
     def _strip_org_frontmatter(self, content: str) -> str:
         """

--- a/findlike/markup.py
+++ b/findlike/markup.py
@@ -1,0 +1,49 @@
+import re
+
+class Markup:
+    def __init__(self, extension: str):
+        self.extension = extension
+        self._MARKUP_EXTENSIONS = {
+            ".org": self._strip_org_frontmatter
+        }
+
+    def strip_frontmatter(self, text: str) -> str:
+            return self._MARKUP_EXTENSIONS[self.extension](text)
+
+    def _strip_org_frontmatter(self, content: str) -> str:
+        """
+        Remove front matter from a string representing an Org-mode file.
+
+        This function removes all lines from `:PROPERTIES:` to `:END:` 
+        and any lines starting with `#+` from the given content string.
+
+        Args:
+            content (str): The content of an Org-mode file as a string.
+
+        Returns:
+            str: The content with the front matter removed.
+
+        Example:
+            >>> content = '''
+            ... :PROPERTIES:
+            ... :ID: 123
+            ... :END:
+            ... #+TITLE: Example
+            ... This is some text.
+            ... ** A heading
+            ... Some more text.
+            ... '''
+            >>> cleaned_content = remove_front_matter(content)
+            >>> print(cleaned_content)
+            This is some text.
+            ** A heading
+            Some more text.
+        """
+        # Remove :PROPERTIES: to :END: block
+        content = re.sub(r':PROPERTIES:(.|\n)*?:END:', '', content)
+        
+        # Remove lines starting with #+
+        pattern = r'^\s*#\+[a-zA-Z0-9_]+.*?$'
+        content = re.sub(pattern, '', content, flags=re.MULTILINE)
+        
+        return content.strip()

--- a/findlike/pytest.ini
+++ b/findlike/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths =
+    tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "findlike"
-version = "1.3.1"
+version = "1.4.0"
 authors = [{ name = "Bruno Arine", email = "bruno.arine@runbox.com" }]
 description = "findlike is a package to retrieve similar documents"
 readme = "README.md"

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -33,7 +33,7 @@ def test_loading_documents(sample_paths):
 
 def test_min_chars_filter(sample_paths):
     corpus = Corpus(sample_paths, min_chars=30)
-    filtered_docs = corpus.documents_
+    filtered_docs = corpus._notnull_documents
     filtered_paths = corpus.paths_
 
     assert len(filtered_docs) == 2
@@ -42,7 +42,7 @@ def test_min_chars_filter(sample_paths):
 
 def test_pruning_documents(sample_paths):
     corpus = Corpus(sample_paths, min_chars=30)
-    assert all(doc is not None for doc in corpus.documents_)
+    assert all(doc is not None for doc in corpus._notnull_documents)
 
 
 def test_pruning_paths(sample_paths):
@@ -68,5 +68,5 @@ def test_try_read_file(sample_paths):
 
 def test_empty_paths_list():
     corpus = Corpus([], min_chars=0)
-    assert len(corpus.documents_) == 0
+    assert len(corpus._notnull_documents) == 0
     assert len(corpus.paths_) == 0

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,5 +1,9 @@
-import pytest
+import tempfile
 from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
 from findlike.preprocessing import Corpus
 from findlike.utils import try_read_file
 
@@ -26,25 +30,6 @@ def sample_paths(tmp_path):
     return [path1, path2, path3]
 
 
-def test_loading_documents(sample_paths):
-    corpus = Corpus(sample_paths, min_chars=0)
-    assert len(corpus._loaded_documents) == 3
-
-
-def test_min_chars_filter(sample_paths):
-    corpus = Corpus(sample_paths, min_chars=30)
-    filtered_docs = corpus._notnull_documents
-    filtered_paths = corpus.paths_
-
-    assert len(filtered_docs) == 2
-    assert len(filtered_paths) == 2
-
-
-def test_pruning_documents(sample_paths):
-    corpus = Corpus(sample_paths, min_chars=30)
-    assert all(doc is not None for doc in corpus._notnull_documents)
-
-
 def test_pruning_paths(sample_paths):
     corpus = Corpus(sample_paths, min_chars=30)
     filtered_paths = corpus.paths_
@@ -66,7 +51,65 @@ def test_try_read_file(sample_paths):
         try_read_file(invalid_path)
 
 
-def test_empty_paths_list():
-    corpus = Corpus([], min_chars=0)
-    assert len(corpus._notnull_documents) == 0
-    assert len(corpus.paths_) == 0
+class TestCorpus:
+    # Fixture for creating temporary files with random content
+    @pytest.fixture
+    def temp_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            file1 = tmp_path / "file1.txt"
+            file2 = tmp_path / "file2.txt"
+            file1.write_text("This is file 1.")
+            file2.write_text("This is file 2.")
+            yield [file1, file2]
+
+    # Fixture for creating a Corpus instance
+    @pytest.fixture
+    def corpus(self):
+        min_chars = 10
+        return Corpus([], min_chars)
+
+    # Test add_from_file method
+    def test_files_were_added(self, corpus, temp_files):
+        # Add files to the corpus
+        corpus.add_from_file(temp_files[0])
+        corpus.add_from_file(temp_files[1])
+
+        # Check if documents and paths are updated correctly
+        assert len(corpus.documents_) == 2
+        assert len(corpus.paths_) == 2
+        assert corpus.documents_[0] == "This is file 1."
+        assert corpus.documents_[1] == "This is file 2."
+        assert corpus.paths_[0] == temp_files[0]
+        assert corpus.paths_[1] == temp_files[1]
+
+    # Test add_from_query method
+    def test_add_from_query(self, corpus):
+        # Add query to the corpus
+        corpus.add_from_query("This is a query.")
+
+        # Check if the query is added to the documents
+        assert len(corpus.documents_) == 1
+        assert len(corpus.paths_) == 0
+        assert corpus.documents_[0] == "This is a query."
+
+    # Test _strip_front_matter method
+    def test_strip_front_matter(self, corpus):
+        # Test with front matter stripping disabled
+        document = "This is a document."
+        stripped_document = corpus.strip_front_matter(document, extension=".txt")
+        assert stripped_document == document
+        
+        # Test with front matter stripping enabled
+        document = """
+        :PROPERTIES:
+        :ID: 123
+        :END:
+        #+TITLE: Example
+        This is some text.
+        ** A heading
+        Some more text.
+        """
+        extension = ".org"
+        expected = "This is some text.\n** A heading\nSome more text."
+        assert corpus.strip_front_matter(dedent(document), extension) == expected

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -1,0 +1,32 @@
+from findlike.markup import Markup
+from textwrap import dedent
+
+class TestMarkup:
+    def test_remove_org_front_matter(self):
+        content = """
+        :PROPERTIES:
+        :ID: 123
+        :END:
+        #+TITLE: Example
+        This is some text.
+        ** A heading
+        Some more text.
+        """
+        extension = ".org"
+        markup = Markup(extension=extension)
+        expected = "This is some text.\n** A heading\nSome more text."
+        assert markup.strip_frontmatter(dedent(content)) == expected
+
+    def test_remove_org_front_matter_empty_input(self):
+        extension = ".org"
+        markup = Markup(extension=extension)
+        content = ""
+        expected = ""
+        assert markup.strip_frontmatter(content) == expected
+
+    def test_remove_org_front_matter_no_front_matter(self):
+        extension = ".org"
+        markup = Markup(extension=extension)
+        content = "This is some text.\n** A heading\nSome more text."
+        expected = "This is some text.\n** A heading\nSome more text."
+        assert markup.strip_frontmatter(content) == expected


### PR DESCRIPTION
Summary of changes:

- Added a new option `-i, --ignore-front-matter` to the `findlike` command line interface.
- Added a new class `Markup` to handle stripping of front matter from markup files like Markdown and Org-mode.
- Updated the `Corpus` class to handle front matter stripping when adding a file to the corpus.
- Added tests for the new functionality.
- Fixed a bug where `findlike` wouldn't read org files if file pattern was explicitly set.