### PR TITLE
fix: reference document issue

### DIFF
--- a/findlike/preprocessing.py
+++ b/findlike/preprocessing.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Callable
 
 from .markup import Markup
-from .utils import compress, try_read_file
+from .utils import try_read_file
 
 WORD_RE = re.compile(r"(?u)\b\w{2,}\b")
 URL_RE = re.compile(r"\S*https?:\S*")
@@ -60,6 +60,7 @@ class Processor:
         """Get only the stems from a list of words."""
         return [self.stemmer(w) for w in tokens]
 
+
 class Corpus:
     """This wrapper provides easy access to a filtered corpus.
 
@@ -85,7 +86,7 @@ class Corpus:
 
         self.documents_: list[str] = []
         self.paths_: list[Path] = []
-        self.reference_: str| None = None
+        self.reference_: str | None = None
 
         self.add_from_paths()
 
@@ -94,13 +95,13 @@ class Corpus:
 
         Args:
             path (Path): The path to the file.
-            is_reference (bool, optional): Indicates if the file is a reference file. 
+            is_reference (bool, optional): Indicates if the file is a reference file.
                 Defaults to False.
 
         Notes:
-            - The file content is added to the corpus if it meets the minimum character 
+            - The file content is added to the corpus if it meets the minimum character
               length requirement.
-            - If front matter stripping is enabled, the file content is stripped of its 
+            - If front matter stripping is enabled, the file content is stripped of its
               front matter before being added to the corpus.
         """
         loaded_doc = try_read_file(path)
@@ -109,14 +110,17 @@ class Corpus:
                 loaded_doc = self.strip_front_matter(
                     loaded_doc, extension=path.suffix
                 )
-            self.documents_.append(loaded_doc)
             if is_reference:
                 self.reference_ = loaded_doc
+                if self.reference_ not in self.documents_:
+                    self.documents_.append(self.reference_)
             else:
+                self.documents_.append(loaded_doc)
                 self.paths_.append(path)
 
     def add_from_query(self, query: str):
         self.documents_.append(query)
+        self.reference_ = query
 
     def add_from_paths(self) -> list[str | None]:
         """Load document contents from the specified paths."""

--- a/findlike/wrappers.py
+++ b/findlike/wrappers.py
@@ -30,9 +30,7 @@ class Tfidf:
         self.target_embeddings_ = self._vectorizer.fit_transform(documents)
 
     def get_scores(self, source: str):
-        # Since the reference has been appended to the corpus, the last
-        # item in the embeddings list will be the reference's.
-        self.reference_embeddings_ = self.target_embeddings_[-1]
+        self.reference_embeddings_ = self._vectorizer.transform([source])
         scores = cosine_similarity(
             self.reference_embeddings_, self.target_embeddings_
         ).flatten()
@@ -61,8 +59,6 @@ class BM25:
         self._model = BM25Okapi(self.tokenized_documents_)
 
     def get_scores(self, source: str):
-        # Since the reference has been appended to the corpus, the last
-        # item in the embeddings list will be the reference's.
-        tokenized_source = self.tokenized_documents_[-1]
+        tokenized_source = self.processor.tokenizer(source)
         scores = self._model.get_scores(tokenized_source)
         return scores

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -113,3 +113,10 @@ class TestCorpus:
         extension = ".org"
         expected = "This is some text.\n** A heading\nSome more text."
         assert corpus.strip_front_matter(dedent(document), extension) == expected
+    
+    def test_reference_duplicity(self, corpus, temp_files):
+        corpus.add_from_file(temp_files[0])
+        corpus.add_from_file(temp_files[1])
+        corpus.add_from_file(temp_files[0], is_reference=True)
+        duplicates = set([x for x in corpus.documents_ if corpus.documents_.count(x) > 1])
+        assert len(duplicates) == 0


### PR DESCRIPTION
### findlike/preprocessing.py - Class `Corpus`
- Modified the `add_from_paths` method to add the reference document to the `documents_` list before other non-reference documents.
- Modified the `add_from_paths` method to append the reference document to the `documents_` list only if it is not already present in the list.
- Modified the `add_from_query` method to set the reference document to the value of the `query` parameter and add it to the `documents_` list.

### findlike/wrappers.py - Class `Tfidf`
- Replaced the line that assigns the last element of `target_embeddings_` to `reference_embeddings_` with a line that transforms the `source` parameter into a vector using the `_vectorizer` object.

### findlike/wrappers.py - Class `BM25`
- Replaced the line that assigns the last element of `tokenized_documents_` to `tokenized_source` with a line that tokenizes the `source` parameter using the `processor` object.

### tests/test_cli.py
- Removed unused imports.
- Modified the `test_formats` function to include the path of the reference file as the first argument to the CLI command.
- Modified the `test_formats` function to sort the JSON output by the `"target"` key in descending order before extracting the scores for comparison with the expected scores.
- Modified the `test_other_extensions` function to include the path of the reference file as the first argument to the CLI command.
- Added a new test function `test_query` to test the CLI command with a query text instead of a reference file.

### tests/test_corpus.py - Class `TestCorpus`
- Added a new test case `test_reference_duplicity` to test that duplicate reference documents are not added to the `documents_` list.